### PR TITLE
chore: add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "main": "dist/project-x.js",
   "name": "project-x",
+  "version": "0.2.0",
   "scripts": {
     "test": "jest",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
Adds a version key to `package.json`. This will allows users to `npm i calebporzio/project-x` without requiring the package to be published to NPM.

### Sidenote

Originally I started this branch hoping to swap `mix` for `rollup` to provide an optional ESM bundle in addition to the UMD. The ESM bundle cuts out a lot of boilerplate that UMD requires, lowering the file size quite a bit. Really useful for those that'll consume the package via npm. 

Getting the babel config working was a total nightmare though, and I eventually gave up. May take another crack at it later. Still wanted to contribute _something_, so here ya go.

---

Related #6