### PR TITLE
Add hidden to boolean attributes

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -271,7 +271,7 @@ export default class Component {
                     }
                 })
             }
-        } else if (['disabled', 'readonly', 'required', 'checked'].includes(attrName)) {
+        } else if (['disabled', 'readonly', 'required', 'checked', 'hidden'].includes(attrName)) {
             // Boolean attributes have to be explicitly added and removed, not just set.
             if (!! value) {
                 el.setAttribute(attrName, '')

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -71,6 +71,7 @@ test('boolean attributes set to false are removed from element', async () => {
             <input x-bind:checked="isSet"></input>
             <input x-bind:required="isSet"></input>
             <input x-bind:readonly="isSet"></input>
+            <input x-bind:hidden="isSet"></input>
         </div>
     `
 
@@ -80,6 +81,7 @@ test('boolean attributes set to false are removed from element', async () => {
     expect(document.querySelectorAll('input')[1].checked).toBeFalsy()
     expect(document.querySelectorAll('input')[2].required).toBeFalsy()
     expect(document.querySelectorAll('input')[3].readOnly).toBeFalsy()
+    expect(document.querySelectorAll('input')[4].hidden).toBeFalsy()
 })
 
 test('boolean attributes set to true are added to element', async () => {


### PR DESCRIPTION
Wanted to toggle the `hidden` [global boolean attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), so I added it.
Was thinking that a boolean value should just toggle any attribute, but didn't want to jump that.